### PR TITLE
fix-for-vim81

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -83,6 +83,9 @@ imap <C-w>t <Esc>:tabnew<ESC>
 nmap <C-w>\| :vnew<ESC>
 imap <C-w>\| <Esc>:vnew<ESC>
 
+"   Fix runtimepath
+" - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+set runtimepath+=/usr/local/share/vim/vim81
 
 "   deni.vim (https://github.com/Shougo/dein.vim)
 " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
- `No such group or event: filetypedetect BufRead`
- `:echo &runtimepath`
  - `/Users/d-tamaki/.vim,/Users/d-tamaki/.vim/dein.vim,/usr/local/share/vim/vimfiles,/usr/local/share/vim/vim80,/usr/local/share/vim/vimfiles
/after,/Users/d-tamaki/.vim/after,/Users/d-tamaki/.fzf`

~~~sh
❯ vim --version | head -n 1
VIM - Vi IMproved 8.1 (2018 May 17, compiled May 18 2018 13:18:24)
~~~